### PR TITLE
build: 클래스 기본 정의를 final 에서 open 으로 설정해주는 plugin.spring 플러그인 추가

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -1,3 +1,6 @@
+plugins {
+    kotlin("plugin.spring")
+}
 
 dependencies {
     implementation(project(":core"))

--- a/api/src/main/kotlin/org/deepforest/dcinside/DcinsideApplication.kt
+++ b/api/src/main/kotlin/org/deepforest/dcinside/DcinsideApplication.kt
@@ -4,7 +4,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
-open class DcinsideApplication
+class DcinsideApplication
 
 fun main(args: Array<String>) {
 	runApplication<DcinsideApplication>(*args)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 	id("org.springframework.boot") version "2.6.1"
 	id("io.spring.dependency-management") version "1.0.11.RELEASE"
 	kotlin("jvm") version "1.6.0"
-	kotlin("plugin.spring") version "1.6.0"
+	kotlin("plugin.spring") version "1.6.0" apply false
 	kotlin("plugin.jpa") version "1.6.0"
 }
 


### PR DESCRIPTION
## Description

어제 얘기했던 부분입니다.

<img src="https://user-images.githubusercontent.com/28972341/144609570-878447a7-e017-493a-b7ea-2653f0e51658.png" width="80%">

<br>

allopen 에 대해서 얘기하길래 좀더 찾아봤습니다.

Kotlin 공식 홈페이지의 [All-open compiler plugin](https://kotlinlang.org/docs/all-open-plugin.html) 을 보면 이건 Spring 에서 제공하는 게 아니라 Kotlin 에서 제공하는 것 같습니다.

Spring 에서는 `allopen` 플러그인 대신 `spring` 플러그인을 사용해서 적용 가능하며 아래와 같은 어노테이션들에 대해 지원해준다고 합니다.

- `@Component`
- `@Async`
- `@Transactional`
- `@Cacheable`
- `@SpringBootTest`

<br>

여기까지 보면 알수 있겠지만 JPA 의 `@Entity` 또한 Proxy 패턴을 사용하기 때문에 별도로 추가해줘야 합니다.

<br>

루트 프로젝트에서는 플러그인이 존재했는데 서브 프로젝트에서는 없어서 그랬던 것 같습니다.

멀티 모듈 (멀티 프로젝트) 로 사용한다면 [Gradle 공식 가이드](https://docs.gradle.org/current/userguide/plugins.html#sec:subprojects_plugins_dsl)에 따라서 아래와 같이 사용하면 됩니다.

<br>

## Reference

- [[kotlin + Spring] 코틀린 환경에서 Spring Boot 사용하기](https://sabarada.tistory.com/180)