### PR TITLE
feat: Open API Swagger 적용

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -5,6 +5,10 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 
+    // swagger
+    implementation("org.springdoc:springdoc-openapi-ui:1.6.1")
+    implementation("org.springdoc:springdoc-openapi-kotlin:1.6.1")
+
     // jwt
     implementation("io.jsonwebtoken:jjwt-api:0.11.2")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.2")

--- a/api/src/main/kotlin/org/deepforest/dcinside/auth/AuthController.kt
+++ b/api/src/main/kotlin/org/deepforest/dcinside/auth/AuthController.kt
@@ -1,5 +1,9 @@
 package org.deepforest.dcinside.auth
 
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.deepforest.dcinside.auth.dto.SigninReqDto
 import org.deepforest.dcinside.auth.dto.SignupReqDto
 import org.deepforest.dcinside.auth.dto.TokenReqDto
@@ -10,11 +14,18 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+@Tag(name = "/auth", description = "인증 API")
 @RequestMapping("/api/v1/auth")
 @RestController
 class AuthController(
     private val authService: AuthService
 ) {
+    @Operation(
+        summary = "회원가입", description = "Request: SignupReqDto, Response: String",
+        responses = [
+            ApiResponse(responseCode = "200", description = "가입 성공 후 username 반환")
+        ]
+    )
     @PostMapping("/signup")
     fun signup(
         @RequestBody signupReqDto: SignupReqDto
@@ -22,6 +33,13 @@ class AuthController(
         authService.signup(signupReqDto)
     )
 
+    @Operation(
+        summary = "로그인",
+        description = "Request: SigninReqDto, Response: TokenDto",
+        responses = [
+            ApiResponse(responseCode = "200", description = "로그인 성공 후 Access Token 발급")
+        ]
+    )
     @PostMapping("/signin")
     fun signin(
         @RequestBody signinReqDto: SigninReqDto
@@ -29,6 +47,13 @@ class AuthController(
         authService.signin(signinReqDto)
     )
 
+    @Operation(
+        summary = "토큰 재발급",
+        description = "Request: TokenReqDto, Response: TokenDto",
+        responses = [
+            ApiResponse(responseCode = "200", description = "RefreshToken 인증 성공 후 새로운 Access Token 발급")
+        ]
+    )
     @PostMapping("/reissue")
     fun reissue(
         @RequestBody tokenReqDto: TokenReqDto

--- a/api/src/main/kotlin/org/deepforest/dcinside/configuration/SecurityConfig.kt
+++ b/api/src/main/kotlin/org/deepforest/dcinside/configuration/SecurityConfig.kt
@@ -28,17 +28,12 @@ class SecurityConfig(
         return BCryptPasswordEncoder()
     }
 
-    // Pass
-    // Swagger / HealthIndicator
+    // Allowed Path
     override fun configure(web: WebSecurity) {
         web.ignoring()
+            // Swagger
             .antMatchers(
-                "/favicon.ico", "/health/**"
-            )
-            .antMatchers(
-                "/v2/api-docs", "/configuration/ui",
-                "/swagger-resources/**", "/configuration/security",
-                "/swagger-ui.html", "/webjars/**", "/swagger/**"
+                "/api-docs", "/swagger-ui.html", "/swagger-ui/**"
             )
     }
 

--- a/api/src/main/kotlin/org/deepforest/dcinside/configuration/SwaggerConfig.kt
+++ b/api/src/main/kotlin/org/deepforest/dcinside/configuration/SwaggerConfig.kt
@@ -1,0 +1,30 @@
+package org.deepforest.dcinside.configuration
+
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.security.SecurityScheme
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class SwaggerConfig {
+
+    @Bean
+    fun openAPI(): OpenAPI {
+        return OpenAPI()
+            .components(
+                Components().addSecuritySchemes(
+                    "bearerScheme",
+                    SecurityScheme().type(SecurityScheme.Type.HTTP)
+                        .scheme("Bearer")
+                        .bearerFormat("JWT")
+                )
+            )
+            .info(
+                Info().title("Dcinside API")
+                    .version("1.0.0")
+                    .description("Dcinside API Docs 페이지입니다.")
+            )
+    }
+}

--- a/api/src/main/resources/application-swagger.yml
+++ b/api/src/main/resources/application-swagger.yml
@@ -1,0 +1,16 @@
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+    configUrl: /api-docs               # configUrl 에 /api-docs 지정
+    disable-swagger-default-url: true   # default config url 삭제
+
+  # api-docs 노출하는 경로 설정 (default: /v3/api-docs)
+  api-docs:
+    path: /api-docs
+
+  # 스웨거에 노출할 API 경로 설정
+  paths-to-match:
+    - /api/v1/**
+
+  cache:
+    disabled: true

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -3,3 +3,4 @@ spring:
     include:
       - jwt
       - db
+      - swagger


### PR DESCRIPTION
## Description

간단할 줄 알았는데 생각보다 이슈가 있었네요.

[Spring Boot 2.6 버전과 Springfox 3.0 (springfox-boot-starter 3.0.0) 이 서로 호환되지 않는 이슈](https://stackoverflow.com/questions/70178343/springfox-3-0-0-is-not-working-with-spring-boot-2-6-0/70178391#70178391)가 있었습니다.

해결방법은 두 가지가 있습니다.

1. Spring Boot 를 2.5 버전대로 낮춘다
2. SpringDoc Open API 의 Swagger 를 사용한다.

Swagger 3.0 을 적용하는 방법은 Springfox 와 SpringDoc 이렇게 두가지가 있는데 설정하는 방법이 조금 다릅니다.

Swagger 때문에 굳이 Spring Boot 버전을 낮추고 싶지 않았고 점점 [SpringDoc 으로 옮겨가는 추세](https://oingdaddy.tistory.com/271) 라고 하여 이번 기회에 적용해봤습니다.

<br>

## Test

로컬에서 실행 후 http://localhost:8080/swagger-ui/index.html 에 접속하면 됩니다.

그 후 페이지 상단에 `/api-docs` 를 입력하면 볼 수 있습니다.