### PR TITLE
feat: Post, Comment, Gallery, BaseEntity 설계

### DIFF
--- a/api/src/main/kotlin/org/deepforest/dcinside/DcinsideApplication.kt
+++ b/api/src/main/kotlin/org/deepforest/dcinside/DcinsideApplication.kt
@@ -2,7 +2,9 @@ package org.deepforest.dcinside
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
+@EnableJpaAuditing
 @SpringBootApplication
 class DcinsideApplication
 

--- a/core/src/main/kotlin/org/deepforest/dcinside/entity/BaseEntity.kt
+++ b/core/src/main/kotlin/org/deepforest/dcinside/entity/BaseEntity.kt
@@ -1,0 +1,21 @@
+package org.deepforest.dcinside.entity
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+import javax.persistence.Column
+import javax.persistence.EntityListeners
+import javax.persistence.MappedSuperclass
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+class BaseEntity {
+    @CreatedDate
+    @Column(name = "createdAt", columnDefinition = "timestamp")
+    var createdAt: LocalDateTime = LocalDateTime.MIN
+
+    @LastModifiedDate
+    @Column(name = "updatedAt", columnDefinition = "timestamp")
+    var updatedAt: LocalDateTime = LocalDateTime.MIN
+}

--- a/core/src/main/kotlin/org/deepforest/dcinside/entity/auth/RefreshToken.kt
+++ b/core/src/main/kotlin/org/deepforest/dcinside/entity/auth/RefreshToken.kt
@@ -1,5 +1,6 @@
 package org.deepforest.dcinside.entity.auth
 
+import org.deepforest.dcinside.entity.BaseEntity
 import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.Id
@@ -15,7 +16,7 @@ class RefreshToken(
 
     @Column(name = "refresh_token_value")
     var value: String
-) {
+) : BaseEntity() {
     fun updateValue(token: String) {
         this.value = token
     }

--- a/core/src/main/kotlin/org/deepforest/dcinside/entity/comment/Comment.kt
+++ b/core/src/main/kotlin/org/deepforest/dcinside/entity/comment/Comment.kt
@@ -1,0 +1,35 @@
+package org.deepforest.dcinside.entity.comment
+
+import org.deepforest.dcinside.entity.BaseEntity
+import org.deepforest.dcinside.entity.member.Member
+import org.deepforest.dcinside.entity.post.Post
+import javax.persistence.*
+
+@Table(name = "comment", indexes = [Index(columnList = "createdAt")])
+@Entity
+class Comment(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    val id: Long,
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id")
+    val member: Member,
+
+    @Column(name = "nickname", updatable = false)
+    val nickname: String,
+
+    @Column(name = "password", updatable = false)
+    val password: String,
+
+    @Column(name = "content", columnDefinition = "text")
+    val content: String,
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "post_id")
+    val post: Post,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "base_comment_id")
+    val baseComment: Comment?
+) : BaseEntity()

--- a/core/src/main/kotlin/org/deepforest/dcinside/entity/gallery/Gallery.kt
+++ b/core/src/main/kotlin/org/deepforest/dcinside/entity/gallery/Gallery.kt
@@ -1,0 +1,26 @@
+package org.deepforest.dcinside.entity.gallery
+
+import org.deepforest.dcinside.entity.BaseEntity
+import org.deepforest.dcinside.entity.post.Post
+import javax.persistence.*
+
+@Entity
+class Gallery(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "gallery_id")
+    val id: Long,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "gallery_type")
+    val type: GalleryType,
+
+    @Column(name = "gallery_name")
+    val name: String,
+
+    @OneToMany(mappedBy = "gallery")
+    val posts: MutableList<Post>
+) : BaseEntity()
+
+enum class GalleryType {
+    MAJOR, MINOR, MINI
+}

--- a/core/src/main/kotlin/org/deepforest/dcinside/entity/member/Member.kt
+++ b/core/src/main/kotlin/org/deepforest/dcinside/entity/member/Member.kt
@@ -1,9 +1,12 @@
 package org.deepforest.dcinside.entity.member
 
+import org.deepforest.dcinside.entity.BaseEntity
+import org.deepforest.dcinside.entity.post.Post
 import javax.persistence.*
 
 
 @Table(
+    name = "member",
     uniqueConstraints = [UniqueConstraint(columnNames = ["username"])]
 )
 @Entity
@@ -13,7 +16,7 @@ class Member(
     @Column(name = "member_id")
     val id: Long? = null,
 
-    @Column(name = "username")
+    @Column(name = "username", nullable = false)
     val username: String,
 
     @Column(name = "password")
@@ -23,9 +26,12 @@ class Member(
     @Column(name = "member_role")
     val role: MemberRole,
 
-    @OneToOne(mappedBy = "member", cascade = [CascadeType.PERSIST, CascadeType.REMOVE])
-    var memberDetail: MemberDetail? = null
-)
+    @OneToOne(mappedBy = "member", fetch = FetchType.LAZY, cascade = [CascadeType.PERSIST, CascadeType.REMOVE])
+    var memberDetail: MemberDetail? = null,
+
+    @OneToMany(mappedBy = "member")
+    val posts: MutableList<Post> = mutableListOf()
+) : BaseEntity()
 
 enum class MemberRole {
     ROLE_NONE, ROLE_BASIC, ROLE_ORANGE, ROLE_BLUE

--- a/core/src/main/kotlin/org/deepforest/dcinside/entity/post/Post.kt
+++ b/core/src/main/kotlin/org/deepforest/dcinside/entity/post/Post.kt
@@ -1,0 +1,37 @@
+package org.deepforest.dcinside.entity.post
+
+import org.deepforest.dcinside.entity.BaseEntity
+import org.deepforest.dcinside.entity.gallery.Gallery
+import org.deepforest.dcinside.entity.member.Member
+import javax.persistence.*
+
+@Table(name = "post", indexes = [Index(columnList = "createdAt")])
+@Entity
+class Post(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_id")
+    val id: Long = 0L,
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id")
+    val member: Member,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "gallery_id")
+    val gallery : Gallery,
+
+    @Column(updatable = false)
+    val nickname : String,
+
+    @Column(updatable = false)
+    val password: String,
+
+    val title: String,
+
+    @Column(name = "content", columnDefinition="text")
+    val content: String,
+
+    @OneToOne(mappedBy = "post", fetch = FetchType.LAZY)
+    val statistics: PostStatistics
+) : BaseEntity() {
+}

--- a/core/src/main/kotlin/org/deepforest/dcinside/entity/post/PostStatistics.kt
+++ b/core/src/main/kotlin/org/deepforest/dcinside/entity/post/PostStatistics.kt
@@ -1,0 +1,34 @@
+package org.deepforest.dcinside.entity.post
+
+import javax.persistence.*
+
+@Table(
+    name = "post_statistics", indexes = [
+        Index(columnList = "viewCount"),
+        Index(columnList = "likeCount"),
+        Index(columnList = "commentCount"),
+    ]
+)
+@Entity
+class PostStatistics(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_statistics_id")
+    val id: Long = 0L,
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    val post: Post,
+
+    @JoinColumn(name = "view_count")
+    var viewCount: Long = 0L,
+
+    @JoinColumn(name = "like_count")
+    var likeCount: Long = 0L,
+
+    @JoinColumn(name = "dislike_count")
+    var dislikeCount: Long = 0L,
+
+    @JoinColumn(name = "comment_count")
+    var commentCount: Long = 0L
+)


### PR DESCRIPTION
## Description

- BaseEntity로 Auditing 설정
- PostStatistics로 통계 필드를 따로 뺐습니다.
    - 필터로 사용하는 필드들이고, 업데이트가 잦은 필드들
    - Redis를 활용하여 업데이트를 5분 간격으로 할 것을 고민 중
    - 인덱스를 1개씩만 걸어버려서, 복합 인덱스에선 성능이 나오지 않을 것 같아 추후에 검색 엔진을 붙이는 것도 고민 중
- Post, Comment는 생성일로 검색 쿼리가 필요하여, createdAt 인덱스 추가
- TODO: Gallery만 등록해놓은 상태인데, Gallery위의 카테고리도 추후에 도입해야 합니다.
- Post에 있는 username, password는 포스트 글에 종속된 것이지 username의 비밀번호와는 상관이 없습니다.
- 유동닉을 가진 유저의 글은 누구든지 해당 글의 패스워드만 안다면 글을 삭제할 수 있습니다.
- 그러나, 가입을 한 유저의 글은 본인만 삭제 가능합니다.
- 글은 갤러리에 종속되어있습니다. (어느 갤러리의 글인지)
- 갤러리는 카테고리에 종속되어있습니다. (어느 카테고리의 갤러리인지) // TODO
- 댓글은 설계상 무한뎁스가 가능하나, application에서 2뎁스만 유효하도록 설정하면 됩니다(baseCommentId = null인 것만 댓글 생성하도록 validation)

## Issue

- https://github.com/Project-DC-Inside/logs/issues/2