### PR TITLE
reafctor: 테스트 실패 수정 및 BaseEntity 날짜 기본값 수정

### DIFF
--- a/api/src/test/resources/application.yml
+++ b/api/src/test/resources/application.yml
@@ -3,6 +3,10 @@ logging:
     org.deepforest.dcinside: debug
 
 spring:
+  profiles:
+    include:
+      - jwt
+      - aws
   jpa:
     hibernate:
       ddl-auto: create

--- a/core/src/main/kotlin/org/deepforest/dcinside/entity/BaseEntity.kt
+++ b/core/src/main/kotlin/org/deepforest/dcinside/entity/BaseEntity.kt
@@ -13,9 +13,9 @@ import javax.persistence.MappedSuperclass
 class BaseEntity {
     @CreatedDate
     @Column(name = "created_at")
-    var createdAt: LocalDateTime = LocalDateTime.MIN
+    var createdAt: LocalDateTime = LocalDateTime.now()
 
     @LastModifiedDate
     @Column(name = "updated_at")
-    var updatedAt: LocalDateTime = LocalDateTime.MIN
+    var updatedAt: LocalDateTime = LocalDateTime.now()
 }


### PR DESCRIPTION
## Description

### 1. 테스트 실패 수정

테스트 코드 돌릴 때 키 주입할 jwt 설정이 없어서 테스트 코드에서도 포함하도록 추가했습니다.

### 2. BaseEntity 날짜 기본값 수정

`LocalDateTime.MIN` 을 기본값으로 설정하면 datetime 불일치가 떠서 쿼리가 실패합니다.

`LocalDateTime.now()` 으로 변경했습니다.