### PR TITLE
feat: Swagger 에서 Security 인증 전역으로 받을 수 있도록 설정 추가

### DIFF
--- a/api/src/main/kotlin/org/deepforest/dcinside/configuration/SwaggerConfig.kt
+++ b/api/src/main/kotlin/org/deepforest/dcinside/configuration/SwaggerConfig.kt
@@ -3,6 +3,7 @@ package org.deepforest.dcinside.configuration
 import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.security.SecurityRequirement
 import io.swagger.v3.oas.models.security.SecurityScheme
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -15,10 +16,18 @@ class SwaggerConfig {
         return OpenAPI()
             .components(
                 Components().addSecuritySchemes(
-                    "bearerScheme",
-                    SecurityScheme().type(SecurityScheme.Type.HTTP)
-                        .scheme("Bearer")
+                    "bearerAuth",
+                    SecurityScheme()
+                        .type(SecurityScheme.Type.HTTP)
+                        .`in`(SecurityScheme.In.HEADER)
+                        .name("Authorization")
+                        .scheme("bearer")
                         .bearerFormat("JWT")
+                )
+            )
+            .security(
+                listOf(
+                    SecurityRequirement().addList("bearerAuth")
                 )
             )
             .info(

--- a/api/src/main/kotlin/org/deepforest/dcinside/configuration/SwaggerConfig.kt
+++ b/api/src/main/kotlin/org/deepforest/dcinside/configuration/SwaggerConfig.kt
@@ -16,18 +16,18 @@ class SwaggerConfig {
         return OpenAPI()
             .components(
                 Components().addSecuritySchemes(
-                    "bearerAuth",
+                    "BearerAuth",
                     SecurityScheme()
                         .type(SecurityScheme.Type.HTTP)
                         .`in`(SecurityScheme.In.HEADER)
                         .name("Authorization")
-                        .scheme("bearer")
+                        .scheme("Bearer")
                         .bearerFormat("JWT")
                 )
             )
             .security(
                 listOf(
-                    SecurityRequirement().addList("bearerAuth")
+                    SecurityRequirement().addList("BearerAuth")
                 )
             )
             .info(

--- a/api/src/main/kotlin/org/deepforest/dcinside/configuration/jwt/TokenProvider.kt
+++ b/api/src/main/kotlin/org/deepforest/dcinside/configuration/jwt/TokenProvider.kt
@@ -36,7 +36,7 @@ class TokenProvider(
     companion object {
         val logger: Logger = LoggerFactory.getLogger(TokenProvider::class.java)
         private const val AUTHORITIES_KEY = "auth"
-        private const val BEARER_TYPE = "bearer"
+        private const val BEARER_TYPE = "Bearer"
         private const val ACCESS_TOKEN_EXPIRE_TIME  = 1000 * 60 * 30 // 30분
         private const val REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7 // 7일
     }


### PR DESCRIPTION
## Description

Swagger 에서 Authorize 에 키값을 추가해서 간단하게 전역 인증 처리하며 api 테스트 할 수 있습니다.

그런데 실제로는 동작하지 않고 있어서 좀 찾아보니 `.security()` 설정을 추가해야 했네요

다른 api 를 만들어서 테스트해보면 curl 예시에 헤더가 정상적으로 찍히는걸 볼 수 있습니다.