### PR TITLE
refactor: ResponseDto 에서 Long 타입 제거

### DIFF
--- a/api/src/main/kotlin/org/deepforest/dcinside/comment/controller/CommentController.kt
+++ b/api/src/main/kotlin/org/deepforest/dcinside/comment/controller/CommentController.kt
@@ -36,9 +36,10 @@ class CommentController(
     fun saveCommentForMember(
         @PathVariable postId: Long,
         @RequestBody dto: CommentWrittenByMemberDto
-    ): ResponseDto<Long> = ResponseDto.ok(
+    ): ResponseDto<Unit> {
         commentForMemberService.saveComment(dto, postId, SecurityUtil.getCurrentMemberId())
-    )
+        return ResponseDto.ok()
+    }
 
     @Operation(summary = "회원이 특정 게시글에 단 댓글 삭제")
     @DeleteMapping("/comments/{commentId}")
@@ -54,9 +55,10 @@ class CommentController(
     fun saveCommentForNonMember(
         @PathVariable postId: Long,
         @RequestBody dto: CommentWrittenByNonMemberDto
-    ): ResponseDto<Long> = ResponseDto.ok(
+    ): ResponseDto<Unit> {
         commentForNonMemberService.saveComment(dto, postId)
-    )
+        return ResponseDto.ok()
+    }
 
     @Operation(summary = "비회원이 특정 게시글에 단 댓글 삭제")
     @DeleteMapping("/comments/non-member/{commentId}")

--- a/api/src/main/kotlin/org/deepforest/dcinside/post/controller/PostController.kt
+++ b/api/src/main/kotlin/org/deepforest/dcinside/post/controller/PostController.kt
@@ -41,18 +41,20 @@ class PostController(
     @PostMapping
     fun savePostForMember(
         @RequestBody postWrittenByMemberDto: PostWrittenByMemberDto
-    ): ResponseDto<Long> = ResponseDto.ok(
+    ): ResponseDto<Unit> {
         postForMemberService.savePost(postWrittenByMemberDto, SecurityUtil.getCurrentMemberId())
-    )
+        return ResponseDto.ok()
+    }
 
     @Operation(summary = "회원의 Post 수정 요청")
     @PutMapping("/{postId}")
     fun updatePostForMember(
         @PathVariable("postId") postId: Long,
         @RequestBody postUpdateDto: PostUpdateDto
-    ): ResponseDto<Long> = ResponseDto.ok(
+    ): ResponseDto<Unit> {
         postForMemberService.updatePost(postId, postUpdateDto, SecurityUtil.getCurrentMemberId())
-    )
+        return ResponseDto.ok()
+    }
 
     @Operation(summary = "회원의 Post 삭제 요청")
     @DeleteMapping("/{postId}")
@@ -67,18 +69,20 @@ class PostController(
     @PostMapping("/non-member")
     fun savePostForNonMember(
         @RequestBody postWrittenByNonMemberDto: PostWrittenByNonMemberDto
-    ): ResponseDto<Long> = ResponseDto.ok(
+    ): ResponseDto<Unit> {
         postForNonMemberService.savePost(postWrittenByNonMemberDto)
-    )
+        return ResponseDto.ok()
+    }
 
     @Operation(summary = "비회원의 Post 수정 요청")
     @PutMapping("/non-member/{postId}")
     fun updatePostForNonMember(
         @PathVariable("postId") postId: Long,
         @RequestBody postUpdateDto: PostUpdateDto
-    ): ResponseDto<Long> = ResponseDto.ok(
+    ): ResponseDto<Unit> {
         postForNonMemberService.updatePost(postId, postUpdateDto)
-    )
+        return ResponseDto.ok()
+    }
 
     @Operation(summary = "비회원의 Post 삭제 요청")
     @DeleteMapping("/non-member/{postId}")


### PR DESCRIPTION
#23 이슈에 대응하는 수정사항입니다.

`Long` 타입으로 내려주니 어떤 값인지 알지 못하는 이슈가 있어서 전부 JSON 형식으로 내려주기로 했습니다.

그런데 굳이 사용하지 않는 값이라면 내려줄 필요가 없어서 클라이언트와 합의 하에 `Unit` 타입으로 내려주기로 함