### PR TITLE
feat: 게시글 작성 시 이미지까지 받도록 추가

### DIFF
--- a/api/src/main/kotlin/org/deepforest/dcinside/configuration/SecurityConfig.kt
+++ b/api/src/main/kotlin/org/deepforest/dcinside/configuration/SecurityConfig.kt
@@ -63,6 +63,7 @@ class SecurityConfig(
             .authorizeRequests()
             .antMatchers("/api/*/auth/**").permitAll()
             .antMatchers("/api/**/non-member/**").permitAll()
+            .antMatchers("/api/*/images/**").permitAll()
             .antMatchers(HttpMethod.GET,"/api/*/comments").permitAll()
             .antMatchers(HttpMethod.GET,"/api/*/posts/**").permitAll()
             .antMatchers(HttpMethod.GET,"/api/*/galleries").permitAll()

--- a/api/src/main/kotlin/org/deepforest/dcinside/post/dto/PostDto.kt
+++ b/api/src/main/kotlin/org/deepforest/dcinside/post/dto/PostDto.kt
@@ -3,6 +3,7 @@ package org.deepforest.dcinside.post.dto
 import org.deepforest.dcinside.entity.gallery.Gallery
 import org.deepforest.dcinside.entity.member.Member
 import org.deepforest.dcinside.entity.post.Post
+import org.deepforest.dcinside.entity.post.PostImage
 import org.deepforest.dcinside.entity.post.PostStatistics
 import org.deepforest.dcinside.helper.TimeFormatHelper
 import org.deepforest.dcinside.member.MemberDto
@@ -11,6 +12,7 @@ class PostWrittenByMemberDto(
     val galleryId: Long,
     val title: String,
     val content: String,
+    val images: List<PostImageDto>
 ) {
     fun toEntity(gallery: Gallery, member: Member) = Post(
         title = title,
@@ -18,7 +20,9 @@ class PostWrittenByMemberDto(
         nickname = member.nickname,
         member = member,
         gallery = gallery
-    )
+    ).also { post ->
+        post.images.addAll(this.images.map { it.toEntity(post) })
+    }
 }
 
 class PostWrittenByNonMemberDto(
@@ -27,6 +31,7 @@ class PostWrittenByNonMemberDto(
     val content: String,
     val nickname: String,
     val password: String,
+    val images: List<PostImageDto>
 ) {
     fun toEntity(gallery: Gallery) = Post(
         title = title,
@@ -34,7 +39,9 @@ class PostWrittenByNonMemberDto(
         nickname = nickname,
         password = password,
         gallery = gallery
-    )
+    ).also { post ->
+        post.images.addAll(this.images.map { it.toEntity(post) })
+    }
 }
 
 class PostUpdateDto(
@@ -56,6 +63,7 @@ class PostResponseDto(
     val postStatistics: PostStatisticsDto,
     val writer: MemberDto,
     var content: String?,
+    val images: List<PostImageDto>
 ) {
     companion object {
         fun from(
@@ -69,7 +77,8 @@ class PostResponseDto(
             TimeFormatHelper.from(post.updatedAt),
             PostStatisticsDto.from(post.statistics),
             if (post.writtenByNonMember) MemberDto.from(post.nickname) else MemberDto.from(post.member!!),
-            if (needContent) post.content else null
+            if (needContent) post.content else null,
+            post.images.map { PostImageDto.from(it) }
         )
     }
 }
@@ -88,4 +97,22 @@ class PostStatisticsDto(
             statistics.commentCount
         )
     }
+}
+
+class PostImageDto(
+    val number: Int,
+    val url: String,
+) {
+    companion object {
+        fun from(postImage: PostImage) = PostImageDto(
+            postImage.number,
+            postImage.url
+        )
+    }
+
+    fun toEntity(post: Post) = PostImage(
+        number = number,
+        url = url,
+        post = post
+    )
 }

--- a/api/src/main/kotlin/org/deepforest/dcinside/upload/ImageUploadController.kt
+++ b/api/src/main/kotlin/org/deepforest/dcinside/upload/ImageUploadController.kt
@@ -1,20 +1,21 @@
 package org.deepforest.dcinside.upload
 
 import org.deepforest.dcinside.dto.ResponseDto
+import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 
-@RequestMapping("/api/v1/image")
+@RequestMapping("/api/v1/images")
 @RestController
 class ImageUploadController(
     private val imageUploadService: ImageUploadService
 ) {
 
-    @PostMapping("/{path}")
+    @PostMapping("/{path}", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     fun upload(
         @PathVariable("path") path: FolderName,
-        @RequestParam file: MultipartFile
-    ): ResponseDto<String> = ResponseDto.ok(
-        imageUploadService.upload(path, file)
+        @RequestParam files: List<MultipartFile>
+    ): ResponseDto<List<String>> = ResponseDto.ok(
+        files.map { imageUploadService.upload(path, it) }
     )
 }

--- a/api/src/main/kotlin/org/deepforest/dcinside/upload/ImageUploadService.kt
+++ b/api/src/main/kotlin/org/deepforest/dcinside/upload/ImageUploadService.kt
@@ -2,6 +2,7 @@ package org.deepforest.dcinside.upload
 
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.CannedAccessControlList
+import com.amazonaws.services.s3.model.ObjectMetadata
 import com.amazonaws.services.s3.model.PutObjectRequest
 import org.apache.commons.lang3.RandomStringUtils
 import org.springframework.beans.factory.annotation.Value
@@ -23,10 +24,16 @@ class ImageUploadService(
         val fileName = createFileName(path, file.contentType!!)
         return client.run {
             putObject(
-                PutObjectRequest(bucket, fileName, file.inputStream, null)
+                PutObjectRequest(bucket, fileName, file.inputStream, getObjectMetadata(file))
                     .withCannedAcl(CannedAccessControlList.PublicRead)
             )
             this.getUrl(bucket, fileName).toString()
+        }
+    }
+
+    private fun getObjectMetadata(file: MultipartFile): ObjectMetadata {
+        return ObjectMetadata().apply {
+            this.contentType = file.contentType
         }
     }
 

--- a/api/src/test/kotlin/org/deepforest/dcinside/post/PostForMemberServiceTest.kt
+++ b/api/src/test/kotlin/org/deepforest/dcinside/post/PostForMemberServiceTest.kt
@@ -48,7 +48,7 @@ class PostForMemberServiceTest {
         galleryRepository.saveAndFlush(gallery)
 
         // when
-        val dto = PostWrittenByMemberDto(gallery.id!!, "title", "content")
+        val dto = PostWrittenByMemberDto(gallery.id!!, "title", "content", mutableListOf())
         val savedPostId = postForMemberService.savePost(dto, member.id!!)
 
         // then

--- a/api/src/test/kotlin/org/deepforest/dcinside/post/PostForNonMemberServiceTest.kt
+++ b/api/src/test/kotlin/org/deepforest/dcinside/post/PostForNonMemberServiceTest.kt
@@ -38,7 +38,7 @@ class PostForNonMemberServiceTest {
         galleryRepository.saveAndFlush(gallery)
 
         // when
-        val dto = PostWrittenByNonMemberDto(gallery.id!!, "title", "content", "nickname", "password")
+        val dto = PostWrittenByNonMemberDto(gallery.id!!, "title", "content", "nickname", "password", mutableListOf())
         val savedPostId = postForNonMemberService.savePost(dto)
 
         // then

--- a/core/src/main/kotlin/org/deepforest/dcinside/entity/post/Post.kt
+++ b/core/src/main/kotlin/org/deepforest/dcinside/entity/post/Post.kt
@@ -33,6 +33,9 @@ class Post(
     @JoinColumn(name = "gallery_id")
     val gallery: Gallery,
 
+    @OneToMany(mappedBy = "post", cascade = [CascadeType.ALL])
+    val images: MutableList<PostImage> = mutableListOf()
+
 ) : BaseEntity() {
 
     @OneToOne(mappedBy = "post", fetch = FetchType.LAZY, cascade = [CascadeType.PERSIST, CascadeType.REMOVE])

--- a/core/src/main/kotlin/org/deepforest/dcinside/entity/post/PostImage.kt
+++ b/core/src/main/kotlin/org/deepforest/dcinside/entity/post/PostImage.kt
@@ -1,0 +1,23 @@
+package org.deepforest.dcinside.entity.post
+
+import org.deepforest.dcinside.entity.BaseEntity
+import javax.persistence.*
+
+@Table(name = "post_image")
+@Entity
+class PostImage(
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_image_id")
+    val id: Long? = null,
+
+    @Column(name = "number")
+    val number: Int,
+
+    @Column(name = "url")
+    val url: String,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    val post: Post
+) : BaseEntity()


### PR DESCRIPTION
## Description

게시글 작성 시 이미지를 받도록 추가했습니다

클라에서 진행하는 게시글 작성 플로우는 아래와 같습니다

1. 사용자가 이미지 및 텍스트를 첨부
2. 이미지는 본문 텍스트 사이사이에 존재 (iOS 에서는 location 값으로 구분됨)
3. 클라에서는 이미지 업로드 API 를 사용해 먼저 이미지 업로드
4. 게시글과 함께 이미지 URL 을 서버에 전달해서 저장
5. **본문 사이사이에 있는 이미지들의 위치를 구분하기 위해 number 값을 함께 전달** (0 부터 시작하는 값이 아닌 iOS location)

```mermaid
sequenceDiagram
    actor User
    participant C as Client
    participant S as Server
    participant D as DB
    participant A as AWS S3
    User->>C: 이미지 첨부 및 게시글 작성
    C->>+S: POST /api/v1/images/post<br/>params: { List<Multipart> }
    S->>+A: 이미지 업로드
    A->>-S: 이미지 URL
    S->>D: 이미지 URL 저장
    S->>-C: 이미지 URL
    C->>+S: POST /api/v1/posts<br/>params: { 게시글 정보, 이미지 URL }
    S->>+D: 데이터 저장
    D->>-S: 완료
    S->>-C: 완료
```