### PR TITLE
feat: Member 정보 내려주는 API 추가

### DIFF
--- a/api/src/main/kotlin/org/deepforest/dcinside/configuration/SecurityConfig.kt
+++ b/api/src/main/kotlin/org/deepforest/dcinside/configuration/SecurityConfig.kt
@@ -61,6 +61,8 @@ class SecurityConfig(
             // auth API 는 토큰이 없는 상태에서 요청이 들어오기 때문에 permitAll 설정
             .and()
             .authorizeRequests()
+            .antMatchers("/api/*/members/me").hasAnyRole("USER", "ADMIN")
+            .antMatchers("/api/*/members/**").permitAll()
             .antMatchers("/api/*/auth/**").permitAll()
             .antMatchers("/api/**/non-member/**").permitAll()
             .antMatchers("/api/*/images/**").permitAll()

--- a/api/src/main/kotlin/org/deepforest/dcinside/member/MemberController.kt
+++ b/api/src/main/kotlin/org/deepforest/dcinside/member/MemberController.kt
@@ -1,0 +1,27 @@
+package org.deepforest.dcinside.member
+
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.deepforest.dcinside.common.SecurityUtil
+import org.deepforest.dcinside.dto.ResponseDto
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "/members", description = "회원 API")
+@RequestMapping("/api/v1/members")
+@RestController
+class MemberController(
+    val memberService: MemberService
+) {
+
+    @GetMapping("/me")
+    fun findMyMemberInfo(): ResponseDto<MemberInfoDto> = ResponseDto.ok(
+        memberService.findByMemberId(SecurityUtil.getCurrentMemberId())
+    )
+
+    @GetMapping("/{username}")
+    fun findMemberInfo(@PathVariable username: String): ResponseDto<MemberInfoDto> = ResponseDto.ok(
+        memberService.findByUsername(username)
+    )
+}

--- a/api/src/main/kotlin/org/deepforest/dcinside/member/MemberDto.kt
+++ b/api/src/main/kotlin/org/deepforest/dcinside/member/MemberDto.kt
@@ -38,6 +38,22 @@ class MemberDto(
     }
 }
 
+class MemberInfoDto(
+    val memberType: MemberType,
+    val nickname: String,
+    val username: String,
+    val email: String
+) {
+    companion object {
+        fun from(member: Member) = MemberInfoDto(
+            MemberType.of(member.role),
+            member.nickname,
+            member.username,
+            member.email
+        )
+    }
+}
+
 enum class MemberType {
     NONE, FLEXIBLE, FIXED, ORANGE, BLUE, ADMIN;
 

--- a/api/src/main/kotlin/org/deepforest/dcinside/member/MemberService.kt
+++ b/api/src/main/kotlin/org/deepforest/dcinside/member/MemberService.kt
@@ -1,0 +1,18 @@
+package org.deepforest.dcinside.member
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class MemberService(
+    private val memberRepository: MemberRepository
+) {
+    fun findByMemberId(memberId: Long): MemberInfoDto {
+        return MemberInfoDto.from(memberRepository.findByMemberId(memberId))
+    }
+
+    fun findByUsername(username: String): MemberInfoDto {
+        return MemberInfoDto.from(memberRepository.findByUsername(username)!!)
+    }
+}

--- a/api/src/test/kotlin/org/deepforest/dcinside/member/MemberServiceTest.kt
+++ b/api/src/test/kotlin/org/deepforest/dcinside/member/MemberServiceTest.kt
@@ -1,0 +1,55 @@
+package org.deepforest.dcinside.member
+
+import org.assertj.core.api.Assertions.*
+import org.deepforest.dcinside.entity.member.Member
+import org.deepforest.dcinside.entity.member.MemberRole
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.annotation.Transactional
+
+@SpringBootTest
+@Transactional
+class MemberServiceTest {
+
+    @Autowired
+    private lateinit var memberService: MemberService
+
+    @Autowired
+    private lateinit var memberRepository: MemberRepository
+
+    @Test
+    @DisplayName("memberId 로 Member 정보 가져오기")
+    fun test1() {
+        // given
+        val member = Member(null, "username", "email", "nickname", "password", MemberRole.ROLE_FIXED)
+        memberRepository.saveAndFlush(member)
+
+        // when
+        val findMember: MemberInfoDto = memberService.findByMemberId(member.id!!)
+
+        // then
+        assertThat(findMember.memberType).isEqualTo(MemberType.of(member.role))
+        assertThat(findMember.nickname).isEqualTo(member.nickname)
+        assertThat(findMember.username).isEqualTo(member.username)
+        assertThat(findMember.email).isEqualTo(member.email)
+    }
+
+    @Test
+    @DisplayName("username 로 Member 정보 가져오기")
+    fun test2() {
+        // given
+        val member = Member(null, "username", "email", "nickname", "password", MemberRole.ROLE_FIXED)
+        memberRepository.saveAndFlush(member)
+
+        // when
+        val findMember: MemberInfoDto = memberService.findByUsername(member.username)
+
+        // then
+        assertThat(findMember.memberType).isEqualTo(MemberType.of(member.role))
+        assertThat(findMember.nickname).isEqualTo(member.nickname)
+        assertThat(findMember.username).isEqualTo(member.username)
+        assertThat(findMember.email).isEqualTo(member.email)
+    }
+}


### PR DESCRIPTION
Member 정보 내려주는 API 가 없어서 추가

- GET /api/v1/members/me: 내정보 조회
- GET /api/v1/members/{username}: 특정 유저 조회