### PR TITLE
feat: view countUp 기능 구현

### DIFF
--- a/api/src/main/kotlin/org/deepforest/dcinside/post/controller/PostController.kt
+++ b/api/src/main/kotlin/org/deepforest/dcinside/post/controller/PostController.kt
@@ -5,18 +5,14 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.deepforest.dcinside.common.SecurityUtil
 import org.deepforest.dcinside.dto.ResponseDto
 import org.deepforest.dcinside.post.dto.*
-import org.deepforest.dcinside.post.service.PostForMemberService
-import org.deepforest.dcinside.post.service.PostForNonMemberService
-import org.deepforest.dcinside.post.service.PostReadService
+import org.deepforest.dcinside.post.service.PostService
 import org.springframework.web.bind.annotation.*
 
 @Tag(name = "/posts", description = "게시글 API")
 @RequestMapping("/api/v1/posts")
 @RestController
 class PostController(
-    val postReadService: PostReadService,
-    val postForMemberService: PostForMemberService,
-    val postForNonMemberService: PostForNonMemberService
+    val postService: PostService,
 ) {
 
     @Operation(summary = "특정 갤러리에 속한 게시글 리스트 조회", description = "리스트로 내려주기 위해 사이즈를 많이 차지할 것 같은 content 는 미포함")
@@ -25,7 +21,7 @@ class PostController(
         @RequestParam(required = true) galleryId: Long,
         @RequestParam(required = false) lastPostId: Long? = Long.MAX_VALUE,
     ): ResponseDto<List<PostResponseDto>> = ResponseDto.ok(
-        postReadService.findPostsByGalleryId(galleryId, lastPostId)
+        postService.findPostsByGalleryId(galleryId, lastPostId)
     )
 
     @Operation(summary = "Post 단건 조회")
@@ -33,7 +29,7 @@ class PostController(
     fun findPost(
         @PathVariable("postId") postId: Long
     ): ResponseDto<PostResponseDto> = ResponseDto.ok(
-        postReadService.findPostById(postId)
+        postService.findPostByIdAndIncreaseViewCount(postId)
     )
 
 
@@ -42,7 +38,7 @@ class PostController(
     fun savePostForMember(
         @RequestBody postWrittenByMemberDto: PostWrittenByMemberDto
     ): ResponseDto<Unit> {
-        postForMemberService.savePost(postWrittenByMemberDto, SecurityUtil.getCurrentMemberId())
+        postService.savePost(postWrittenByMemberDto, SecurityUtil.getCurrentMemberId())
         return ResponseDto.ok()
     }
 
@@ -52,7 +48,7 @@ class PostController(
         @PathVariable("postId") postId: Long,
         @RequestBody postUpdateDto: PostUpdateDto
     ): ResponseDto<Unit> {
-        postForMemberService.updatePost(postId, postUpdateDto, SecurityUtil.getCurrentMemberId())
+        postService.updatePost(postId, postUpdateDto, SecurityUtil.getCurrentMemberId())
         return ResponseDto.ok()
     }
 
@@ -61,7 +57,7 @@ class PostController(
     fun deletePostForMember(
         @PathVariable("postId") postId: Long
     ): ResponseDto<Unit> = ResponseDto.ok(
-        postForMemberService.deletePost(postId, SecurityUtil.getCurrentMemberId())
+        postService.deletePost(postId, SecurityUtil.getCurrentMemberId())
     )
 
 
@@ -70,7 +66,7 @@ class PostController(
     fun savePostForNonMember(
         @RequestBody postWrittenByNonMemberDto: PostWrittenByNonMemberDto
     ): ResponseDto<Unit> {
-        postForNonMemberService.savePost(postWrittenByNonMemberDto)
+        postService.savePost(postWrittenByNonMemberDto)
         return ResponseDto.ok()
     }
 
@@ -80,7 +76,7 @@ class PostController(
         @PathVariable("postId") postId: Long,
         @RequestBody postUpdateDto: PostUpdateDto
     ): ResponseDto<Unit> {
-        postForNonMemberService.updatePost(postId, postUpdateDto)
+        postService.updatePost(postId, postUpdateDto)
         return ResponseDto.ok()
     }
 
@@ -89,7 +85,7 @@ class PostController(
     fun deletePostForNonMember(
         @PathVariable("postId") postId: Long
     ): ResponseDto<Unit> = ResponseDto.ok(
-        postForNonMemberService.deletePost(postId)
+        postService.deletePost(postId)
     )
 
     @Operation(summary = "비회원의 Post 호출 전 비밀번호 확인 API")
@@ -97,6 +93,6 @@ class PostController(
     fun checkAccess(
         @RequestBody postAccessDto: PostAccessDto
     ): ResponseDto<Boolean> = ResponseDto.ok(
-        postForNonMemberService.checkAccess(postAccessDto)
+        postService.checkAccess(postAccessDto)
     )
 }

--- a/api/src/main/kotlin/org/deepforest/dcinside/post/service/PostReadQueryService.kt
+++ b/api/src/main/kotlin/org/deepforest/dcinside/post/service/PostReadQueryService.kt
@@ -1,0 +1,28 @@
+package org.deepforest.dcinside.post.service
+
+import org.deepforest.dcinside.gallery.GalleryRepository
+import org.deepforest.dcinside.gallery.findByGalleryId
+import org.deepforest.dcinside.post.dto.PostResponseDto
+import org.deepforest.dcinside.post.repository.PostRepository
+import org.deepforest.dcinside.post.repository.findByGalleryWithPaging
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class PostReadQueryService(
+    private val postRepository: PostRepository,
+    private val galleryRepository: GalleryRepository,
+) {
+    fun findPostsByGalleryId(
+        galleryId: Long,
+        lastPostId: Long? = Long.MAX_VALUE
+    ): List<PostResponseDto> {
+        return galleryRepository.findByGalleryId(galleryId)
+            .let {
+                postRepository.findByGalleryWithPaging(it, lastPostId ?: Long.MAX_VALUE)
+            }.map {
+                PostResponseDto.from(it, needContent = false)
+            }
+    }
+}

--- a/api/src/main/kotlin/org/deepforest/dcinside/post/service/PostReadService.kt
+++ b/api/src/main/kotlin/org/deepforest/dcinside/post/service/PostReadService.kt
@@ -1,35 +1,20 @@
 package org.deepforest.dcinside.post.service
 
-import org.deepforest.dcinside.gallery.GalleryRepository
-import org.deepforest.dcinside.gallery.findByGalleryId
 import org.deepforest.dcinside.post.dto.PostResponseDto
 import org.deepforest.dcinside.post.repository.PostRepository
-import org.deepforest.dcinside.post.repository.findByGalleryWithPaging
 import org.deepforest.dcinside.post.repository.findByPostId
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
-@Transactional(readOnly = true)
 class PostReadService(
     private val postRepository: PostRepository,
-    private val galleryRepository: GalleryRepository,
 ) {
-    fun findPostsByGalleryId(
-        galleryId: Long,
-        lastPostId: Long? = Long.MAX_VALUE
-    ): List<PostResponseDto> {
-        return galleryRepository.findByGalleryId(galleryId)
-            .let {
-                postRepository.findByGalleryWithPaging(it, lastPostId ?: Long.MAX_VALUE)
-            }.map {
-                PostResponseDto.from(it, needContent = false)
-            }
-    }
-
-    fun findPostById(postId: Long): PostResponseDto {
+    @Transactional
+    fun findPostByIdAndIncreaseViewCount(postId: Long): PostResponseDto {
         return postRepository.findByPostId(postId)
             .let {
+                it.viewCountUp()
                 PostResponseDto.from(it, needContent = true)
             }
     }

--- a/api/src/main/kotlin/org/deepforest/dcinside/post/service/PostService.kt
+++ b/api/src/main/kotlin/org/deepforest/dcinside/post/service/PostService.kt
@@ -1,0 +1,52 @@
+package org.deepforest.dcinside.post.service
+
+import org.deepforest.dcinside.common.SecurityUtil
+import org.deepforest.dcinside.post.dto.*
+import org.springframework.stereotype.Service
+
+@Service
+class PostService(
+    val postReadQueryService: PostReadQueryService,
+    val postReadService: PostReadService,
+    val postForMemberService: PostForMemberService,
+    val postForNonMemberService: PostForNonMemberService,
+) {
+    fun findPostsByGalleryId(
+        galleryId: Long,
+        lastPostId: Long? = Long.MAX_VALUE
+    ): List<PostResponseDto> {
+        return postReadQueryService.findPostsByGalleryId(galleryId, lastPostId)
+    }
+
+    fun findPostByIdAndIncreaseViewCount(postId: Long): PostResponseDto {
+        return postReadService.findPostByIdAndIncreaseViewCount(postId)
+    }
+
+    fun savePost(dto: PostWrittenByMemberDto, memberId: Long): Long {
+        return postForMemberService.savePost(dto, memberId)
+    }
+
+    fun updatePost(postId: Long, dto: PostUpdateDto, memberId: Long): Long {
+        return postForMemberService.updatePost(postId, dto, memberId)
+    }
+
+    fun savePost(dto: PostWrittenByNonMemberDto): Long {
+        return postForNonMemberService.savePost(dto)
+    }
+
+    fun updatePost(postId: Long, dto: PostUpdateDto): Long {
+        return postForNonMemberService.updatePost(postId, dto)
+    }
+
+    fun deletePost(postId: Long) {
+        postForNonMemberService.deletePost(postId)
+    }
+
+    fun deletePost(postId: Long, memberId: Long) {
+        postForMemberService.deletePost(postId, SecurityUtil.getCurrentMemberId())
+    }
+
+    fun checkAccess(dto: PostAccessDto): Boolean {
+        return postForNonMemberService.checkAccess(dto)
+    }
+}

--- a/api/src/test/kotlin/org/deepforest/dcinside/post/PostReadQueryServiceTest.kt
+++ b/api/src/test/kotlin/org/deepforest/dcinside/post/PostReadQueryServiceTest.kt
@@ -1,0 +1,95 @@
+package org.deepforest.dcinside.post
+
+import org.assertj.core.api.Assertions.assertThat
+import org.deepforest.dcinside.entity.gallery.Gallery
+import org.deepforest.dcinside.entity.gallery.GalleryType
+import org.deepforest.dcinside.entity.member.Member
+import org.deepforest.dcinside.entity.member.MemberRole
+import org.deepforest.dcinside.entity.post.Post
+import org.deepforest.dcinside.gallery.GalleryRepository
+import org.deepforest.dcinside.member.MemberRepository
+import org.deepforest.dcinside.post.dto.PostResponseDto
+import org.deepforest.dcinside.post.repository.PostRepository
+import org.deepforest.dcinside.post.service.PostReadQueryService
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.annotation.Transactional
+
+@SpringBootTest
+@Transactional
+class PostReadQueryServiceTest {
+
+    @Autowired
+    private lateinit var postReadQueryService: PostReadQueryService
+
+    @Autowired
+    private lateinit var memberRepository: MemberRepository
+
+    @Autowired
+    private lateinit var postRepository: PostRepository
+
+    @Autowired
+    private lateinit var galleryRepository: GalleryRepository
+
+    @Test
+    @DisplayName("특정 갤러리의 게시글 리스트 가져오기. 리스트가 제공되기 때문에 사이즈가 클 수도 있는 content 는 null 로 내려줌")
+    fun testFindLists() {
+        // given
+        val member = Member(null, "username", "email", "nickname", "password", MemberRole.ROLE_FIXED)
+        memberRepository.saveAndFlush(member)
+
+        val majorGallery = Gallery(null, GalleryType.MAJOR, "major-gallery")
+        val minorGallery = Gallery(null, GalleryType.MINOR, "minor-gallery")
+        galleryRepository.saveAndFlush(minorGallery)
+        galleryRepository.saveAndFlush(majorGallery)
+
+        repeat(10) {
+            val post = Post(
+                null,
+                "major-nickname-$it",
+                "major-title-$it",
+                "major-content-$it",
+                "major-password-$it",
+                member,
+                majorGallery
+            )
+            postRepository.saveAndFlush(post)
+        }
+        repeat(5) {
+            val post = Post(
+                null,
+                "minor-nickname-$it",
+                "minor-title-$it",
+                "minor-content-$it",
+                "minor-password-$it",
+                member,
+                minorGallery
+            )
+            postRepository.saveAndFlush(post)
+        }
+
+        // when
+        val majorPosts: List<PostResponseDto> = postReadQueryService.findPostsByGalleryId(majorGallery.id!!)
+        val minorPosts: List<PostResponseDto> = postReadQueryService.findPostsByGalleryId(minorGallery.id!!)
+
+        // then
+        assertThat(majorPosts.size).isEqualTo(10)
+        assertThat(minorPosts.size).isEqualTo(5)
+
+        majorPosts.reversed().forEachIndexed { index, res ->
+            assertThat(res.id).isNotNull
+            assertThat(res.nickname).isEqualTo("major-nickname-$index")
+            assertThat(res.title).isEqualTo("major-title-$index")
+            assertThat(res.content).isNull()
+        }
+
+        minorPosts.reversed().forEachIndexed { index, res ->
+            assertThat(res.id).isNotNull
+            assertThat(res.nickname).isEqualTo("minor-nickname-$index")
+            assertThat(res.title).isEqualTo("minor-title-$index")
+            assertThat(res.content).isNull()
+        }
+    }
+}

--- a/api/src/test/kotlin/org/deepforest/dcinside/post/PostReadServiceTest.kt
+++ b/api/src/test/kotlin/org/deepforest/dcinside/post/PostReadServiceTest.kt
@@ -1,6 +1,6 @@
 package org.deepforest.dcinside.post
 
-import org.assertj.core.api.Assertions.*
+import org.assertj.core.api.Assertions.assertThat
 import org.deepforest.dcinside.entity.gallery.Gallery
 import org.deepforest.dcinside.entity.gallery.GalleryType
 import org.deepforest.dcinside.entity.member.Member
@@ -10,9 +10,9 @@ import org.deepforest.dcinside.gallery.GalleryRepository
 import org.deepforest.dcinside.helper.TimeFormatHelper
 import org.deepforest.dcinside.member.MemberRepository
 import org.deepforest.dcinside.member.MemberType
-import org.deepforest.dcinside.post.dto.PostResponseDto
 import org.deepforest.dcinside.post.repository.PostRepository
 import org.deepforest.dcinside.post.service.PostReadService
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -36,107 +36,73 @@ class PostReadServiceTest {
     @Autowired
     private lateinit var galleryRepository: GalleryRepository
 
-    @Test
-    @DisplayName("특정 갤러리의 게시글 리스트 가져오기. 리스트가 제공되기 때문에 사이즈가 클 수도 있는 content 는 null 로 내려줌")
-    fun testFindLists() {
-        // given
-        val member = Member(null, "username", "email", "nickname", "password", MemberRole.ROLE_FIXED)
-        memberRepository.saveAndFlush(member)
-
-        val majorGallery = Gallery(null, GalleryType.MAJOR, "major-gallery")
-        val minorGallery = Gallery(null, GalleryType.MINOR, "minor-gallery")
-        galleryRepository.saveAndFlush(minorGallery)
-        galleryRepository.saveAndFlush(majorGallery)
-
-        repeat (10) {
-            val post = Post(null, "major-nickname-$it", "major-title-$it", "major-content-$it", "major-password-$it", member, majorGallery)
-            postRepository.saveAndFlush(post)
-        }
-        repeat (5) {
-            val post = Post(null, "minor-nickname-$it", "minor-title-$it", "minor-content-$it", "minor-password-$it", member, minorGallery)
-            postRepository.saveAndFlush(post)
-        }
-
-        // when
-        val majorPosts: List<PostResponseDto> = postReadService.findPostsByGalleryId(majorGallery.id!!)
-        val minorPosts: List<PostResponseDto> = postReadService.findPostsByGalleryId(minorGallery.id!!)
-
-        // then
-        assertThat(majorPosts.size).isEqualTo(10)
-        assertThat(minorPosts.size).isEqualTo(5)
-
-        majorPosts.reversed().forEachIndexed { index, res ->
-            assertThat(res.id).isNotNull
-            assertThat(res.nickname).isEqualTo("major-nickname-$index")
-            assertThat(res.title).isEqualTo("major-title-$index")
-            assertThat(res.content).isNull()
-        }
-
-        minorPosts.reversed().forEachIndexed { index, res ->
-            assertThat(res.id).isNotNull
-            assertThat(res.nickname).isEqualTo("minor-nickname-$index")
-            assertThat(res.title).isEqualTo("minor-title-$index")
-            assertThat(res.content).isNull()
-        }
-    }
-
     @Nested
     @DisplayName("게시글 단건 조회 테스트: post.member 가 존재하면 회원, 없으면 비회원")
     inner class FindPost {
 
-        @Test
-        @DisplayName("회원이 작성한 글에는 writer.username 존재")
-        fun testFindPostByRealMember() {
-            // given
-            val member = Member(null, "username", "email", "nickname", "password", MemberRole.ROLE_FIXED)
+        private lateinit var post: Post
+        private lateinit var member: Member
+
+        @BeforeEach
+        internal fun setUp() {
+            member = Member(null, "username", "email", "nickname", "password", MemberRole.ROLE_FIXED)
             memberRepository.saveAndFlush(member)
 
             val gallery = Gallery(null, GalleryType.MAJOR, "major-gallery")
             galleryRepository.saveAndFlush(gallery)
 
-            val post = Post(null, "nickname", "major-title", "major-content", "major-password", member, gallery)
+
+            post = Post(null, "nickname", "major-title", "major-content", "major-password", member, gallery)
             postRepository.saveAndFlush(post)
+        }
+
+        @DisplayName("회원이 작성한 글에는 writer.username 이 존재한다.")
+        @Test
+        fun testFindPostByRealMember() {
 
             // when
-            val postDto: PostResponseDto = postReadService.findPostById(post.id!!)
+            val response = postReadService.findPostByIdAndIncreaseViewCount(post.id!!)
 
             // then
-            assertThat(postDto.id).isEqualTo(post.id)
-            assertThat(postDto.nickname).isEqualTo(post.nickname)
-            assertThat(postDto.title).isEqualTo(post.title)
-            assertThat(postDto.content).isEqualTo(post.content)
-            assertThat(postDto.createdAt).isEqualTo(TimeFormatHelper.from(post.createdAt))
-            assertThat(postDto.updatedAt).isEqualTo(TimeFormatHelper.from(post.updatedAt))
+            assertThat(response.id).isEqualTo(post.id)
+            assertThat(response.nickname).isEqualTo(post.nickname)
+            assertThat(response.title).isEqualTo(post.title)
+            assertThat(response.content).isEqualTo(post.content)
+            assertThat(response.createdAt).isEqualTo(TimeFormatHelper.from(post.createdAt))
+            assertThat(response.updatedAt).isEqualTo(TimeFormatHelper.from(post.updatedAt))
 
-            assertThat(postDto.writer.memberType).isEqualTo(MemberType.FIXED)
-            assertThat(postDto.writer.nickname).isEqualTo(member.nickname)
-            assertThat(postDto.writer.username).isEqualTo(member.username)
+            assertThat(response.writer.memberType).isEqualTo(MemberType.FIXED)
+            assertThat(response.writer.nickname).isEqualTo(member.nickname)
+            assertThat(response.writer.username).isEqualTo(member.username)
         }
 
         @Test
-        @DisplayName("비회원이 작성한 글은 writer.username 없음")
+        @DisplayName("비회원이 작성한 글은 writer.username 이 존재하지 않는다.")
         fun testFindPostByNonMember() {
-            // given
-            val gallery = Gallery(null, GalleryType.MAJOR, "major-gallery")
-            galleryRepository.saveAndFlush(gallery)
-
-            val post = Post(null, "nickname", "major-title", "major-content", password = null, member = null, gallery)
-            postRepository.saveAndFlush(post)
-
             // when
-            val postDto: PostResponseDto = postReadService.findPostById(post.id!!)
+            val response = postReadService.findPostByIdAndIncreaseViewCount(post.id!!)
 
             // then
-            assertThat(postDto.id).isEqualTo(post.id)
-            assertThat(postDto.nickname).isEqualTo(post.nickname)
-            assertThat(postDto.title).isEqualTo(post.title)
-            assertThat(postDto.content).isEqualTo(post.content)
-            assertThat(postDto.createdAt).isEqualTo(TimeFormatHelper.from(post.createdAt))
-            assertThat(postDto.updatedAt).isEqualTo(TimeFormatHelper.from(post.updatedAt))
+            assertThat(response.id).isEqualTo(post.id)
+            assertThat(response.nickname).isEqualTo(post.nickname)
+            assertThat(response.title).isEqualTo(post.title)
+            assertThat(response.content).isEqualTo(post.content)
+            assertThat(response.createdAt).isEqualTo(TimeFormatHelper.from(post.createdAt))
+            assertThat(response.updatedAt).isEqualTo(TimeFormatHelper.from(post.updatedAt))
 
-            assertThat(postDto.writer.memberType).isEqualTo(MemberType.NONE)
-            assertThat(postDto.writer.nickname).isEqualTo(post.nickname)
-            assertThat(postDto.writer.username).isNull()
+            assertThat(response.writer.memberType).isEqualTo(MemberType.NONE)
+            assertThat(response.writer.nickname).isEqualTo(post.nickname)
+            assertThat(response.writer.username).isNull()
+        }
+
+        @DisplayName("게시글이 조회되면, 조회 카운트가 1회 증가한다.")
+        @Test
+        fun increaseViewCountTest() {
+            // when
+            val response = postReadService.findPostByIdAndIncreaseViewCount(post.id!!)
+
+            // then
+            assertThat(response.postStatistics.viewCount).isEqualTo(1)
         }
     }
 }

--- a/core/src/main/kotlin/org/deepforest/dcinside/entity/post/Post.kt
+++ b/core/src/main/kotlin/org/deepforest/dcinside/entity/post/Post.kt
@@ -46,4 +46,8 @@ class Post(
     fun wasNotWrittenBy(other: Member): Boolean = (other == this.member)
 
     fun isSamePassword(otherPassword: String): Boolean = (otherPassword == this.password)
+
+    fun viewCountUp() {
+        statistics.viewCountUp()
+    }
 }

--- a/core/src/main/kotlin/org/deepforest/dcinside/entity/post/PostStatistics.kt
+++ b/core/src/main/kotlin/org/deepforest/dcinside/entity/post/PostStatistics.kt
@@ -21,9 +21,6 @@ class PostStatistics(
     @JoinColumn(name = "post_id")
     val post: Post,
 
-    @JoinColumn(name = "view_count")
-    var viewCount: Long = 0L,
-
     @JoinColumn(name = "like_count")
     var likeCount: Long = 0L,
 
@@ -32,4 +29,14 @@ class PostStatistics(
 
     @JoinColumn(name = "comment_count")
     var commentCount: Long = 0L,
-)
+
+    viewCount: Long = 0L,
+) {
+    @JoinColumn(name = "view_count")
+    var viewCount: Long = viewCount
+        protected set
+
+    fun viewCountUp() {
+        viewCount++
+    }
+}


### PR DESCRIPTION
## 관련 스레드 & 이슈
- https://deep-foresthq.slack.com/archives/C02NSTG4QQL/p1664095288905929

## 구현내용
- 단건 호출시 viewCount 를 increase 하도록 구현하였습니다. HTTP MEHOTD가 **GET** 이라 조금 고민하긴했지만, 비즈니스상 크게 중요하지 않은 부분이기도하고, 적당히 다른것으로 바꾸기도 애매해서 GET을 유지했습니다.
- POST에서 쿼리성 서비스를 분리했습니다.

## 추가적으로 하고 싶은말 
- ~~로컬에서 테스트할 수 있는 방법에 대한 가이드가 있으면 좋겠습니다. 현재 테스트 코드 분리 및 작성은 하였으나 테스트를 못돌려보아서 DRAFT 로 올려둡니다.~~ **설정파일 전달 완료**
- 현재 POST Entity 구조가 `PostStatistics` 를 OneToOne 관계로 들고있는 상황인데, 해당 부분을 추후 논의 후 개선했으면 합니다. 
- 또한 `PostStatistics` 에서 `commentCount` 도 알고 있는 형태인데, 현재 Commnet : Post 는 단방향 관계를 맺고 있고, commentCount 기능을 제공하기 위해 양방향 매핑을 하는것보다는 아예 `commentCount` 는 `PostStatistics` 에서 관리하지 않는것이 어떨까 의견내봅니다.