### PR TITLE
feat: 테스트용 어노테이션 구현

### DIFF
--- a/api/src/test/kotlin/org/deepforest/dcinside/BaseTests.kt
+++ b/api/src/test/kotlin/org/deepforest/dcinside/BaseTests.kt
@@ -1,0 +1,26 @@
+package org.deepforest.dcinside
+
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.TestConstructor
+import org.springframework.transaction.annotation.Transactional
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+annotation class TestEnvironment
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@DataJpaTest
+@TestEnvironment
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+annotation class RepositoryTest
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@Transactional
+@SpringBootTest
+@TestEnvironment
+annotation class IntegrationTest

--- a/api/src/test/kotlin/org/deepforest/dcinside/comment/CommentReadServiceTest.kt
+++ b/api/src/test/kotlin/org/deepforest/dcinside/comment/CommentReadServiceTest.kt
@@ -1,6 +1,7 @@
 package org.deepforest.dcinside.comment
 
-import org.assertj.core.api.Assertions.*
+import org.assertj.core.api.Assertions.assertThat
+import org.deepforest.dcinside.IntegrationTest
 import org.deepforest.dcinside.comment.dto.CommentResponseDto
 import org.deepforest.dcinside.comment.repository.CommentRepository
 import org.deepforest.dcinside.comment.service.CommentReadService
@@ -15,29 +16,15 @@ import org.deepforest.dcinside.member.MemberRepository
 import org.deepforest.dcinside.post.repository.PostRepository
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.transaction.annotation.Transactional
 
-@Transactional
-@SpringBootTest
-class CommentReadServiceTest {
-
-    @Autowired
-    private lateinit var commentReadService: CommentReadService
-
-    @Autowired
-    private lateinit var commentRepository: CommentRepository
-
-    @Autowired
-    private lateinit var memberRepository: MemberRepository
-
-    @Autowired
-    private lateinit var postRepository: PostRepository
-
-    @Autowired
-    private lateinit var galleryRepository: GalleryRepository
-
+@IntegrationTest
+class CommentReadServiceTest(
+    private val commentReadService: CommentReadService,
+    private val commentRepository: CommentRepository,
+    private val memberRepository: MemberRepository,
+    private val postRepository: PostRepository,
+    private val galleryRepository: GalleryRepository,
+) {
     @Test
     @DisplayName("특정 게시글의 댓글 리스트 가져오기. 오래된 순으로 20개 전달")
     fun testFindList() {
@@ -49,7 +36,7 @@ class CommentReadServiceTest {
         galleryRepository.saveAndFlush(gallery)
         postRepository.saveAndFlush(post)
 
-        repeat (30) {
+        repeat(30) {
             val comment = Comment(content = "comment-content-$it", post, member)
             commentRepository.saveAndFlush(comment)
         }
@@ -75,7 +62,7 @@ class CommentReadServiceTest {
         galleryRepository.saveAndFlush(gallery)
         postRepository.saveAndFlush(post)
 
-        repeat (30) {
+        repeat(30) {
             val comment = Comment(content = "comment-content-$it", post, member)
             commentRepository.saveAndFlush(comment)
             val nestedComment = Comment(content = "nested-content-$it", post, member, comment)
@@ -104,7 +91,7 @@ class CommentReadServiceTest {
         galleryRepository.saveAndFlush(gallery)
         postRepository.saveAndFlush(post)
 
-        repeat (30) {
+        repeat(30) {
             val comment = Comment(content = "comment-content-$it", post, member)
             commentRepository.saveAndFlush(comment)
         }
@@ -129,8 +116,13 @@ class CommentReadServiceTest {
         galleryRepository.saveAndFlush(gallery)
         postRepository.saveAndFlush(post)
 
-        repeat (30) {
-            val comment = Comment(content = "comment-content-$it", nickname = "comment-nickname-$it", password = "comment-password-$it", post = post)
+        repeat(30) {
+            val comment = Comment(
+                content = "comment-content-$it",
+                nickname = "comment-nickname-$it",
+                password = "comment-password-$it",
+                post = post
+            )
             commentRepository.saveAndFlush(comment)
         }
 

--- a/api/src/test/kotlin/org/deepforest/dcinside/comment/CommentRepositoryTest.kt
+++ b/api/src/test/kotlin/org/deepforest/dcinside/comment/CommentRepositoryTest.kt
@@ -1,6 +1,7 @@
 package org.deepforest.dcinside.comment
 
-import org.assertj.core.api.Assertions.*
+import org.assertj.core.api.Assertions.assertThat
+import org.deepforest.dcinside.RepositoryTest
 import org.deepforest.dcinside.comment.repository.CommentRepository
 import org.deepforest.dcinside.comment.repository.findByPostWithPaging
 import org.deepforest.dcinside.entity.comment.Comment
@@ -14,27 +15,15 @@ import org.deepforest.dcinside.member.MemberRepository
 import org.deepforest.dcinside.post.repository.PostRepository
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.*
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = Replace.NONE)
-class CommentRepositoryTest {
 
-    @Autowired
-    private lateinit var commentRepository: CommentRepository
-
-    @Autowired
-    private lateinit var memberRepository: MemberRepository
-
-    @Autowired
-    private lateinit var postRepository: PostRepository
-
-    @Autowired
-    private lateinit var galleryRepository: GalleryRepository
-
+@RepositoryTest
+class CommentRepositoryTest(
+    private val commentRepository: CommentRepository,
+    private val memberRepository: MemberRepository,
+    private val postRepository: PostRepository,
+    private val galleryRepository: GalleryRepository,
+) {
     @Test
     @DisplayName("회원의 댓글 생성/조회 성공")
     fun testSave() {
@@ -70,7 +59,12 @@ class CommentRepositoryTest {
         postRepository.saveAndFlush(post)
 
         // when
-        val comment = Comment(content = "comment-content", post = post, nickname = "non-member-nickname", password = "comment-password")
+        val comment = Comment(
+            content = "comment-content",
+            post = post,
+            nickname = "non-member-nickname",
+            password = "comment-password"
+        )
         commentRepository.saveAndFlush(comment)
 
         // then
@@ -93,8 +87,13 @@ class CommentRepositoryTest {
         galleryRepository.saveAndFlush(gallery)
         postRepository.saveAndFlush(post)
 
-        repeat (30) {
-            val comment = Comment(content = "comment-content-$it", post = post, nickname = "non-member-nickname-$it", password = "comment-password-$it")
+        repeat(30) {
+            val comment = Comment(
+                content = "comment-content-$it",
+                post = post,
+                nickname = "non-member-nickname-$it",
+                password = "comment-password-$it"
+            )
             commentRepository.saveAndFlush(comment)
         }
 


### PR DESCRIPTION
## 관련 스레드 & 이슈

## 구현내용
- 테스트용 어노테이션을 구현하였습니다.
- kopring + junit5 의 경우 필드 주입이 필수적이지 않고, 생성자 프로퍼티로도 빈 주입을 받을 수 있습니다.
- 해당 어노테이션을 사용함으로써 `@AutoWired` 와 같은 보일러 플레이트를 생략할 수 있습니다.

## 추가적으로 하고 싶은말 
- 기존 어노테이션을 다 바꿀까 하다가 귀찮아서 일단 미루어두었습니다. ㅎㅎ;