### PR TITLE
fix: /members/me API 는 role 에 관계 없이 로그인 상태에서 호출가능

### DIFF
--- a/api/src/main/kotlin/org/deepforest/dcinside/configuration/SecurityConfig.kt
+++ b/api/src/main/kotlin/org/deepforest/dcinside/configuration/SecurityConfig.kt
@@ -61,7 +61,7 @@ class SecurityConfig(
             // auth API 는 토큰이 없는 상태에서 요청이 들어오기 때문에 permitAll 설정
             .and()
             .authorizeRequests()
-            .antMatchers("/api/*/members/me").hasAnyRole("USER", "ADMIN")
+            .antMatchers("/api/*/members/me").authenticated()
             .antMatchers("/api/*/members/**").permitAll()
             .antMatchers("/api/*/auth/**").permitAll()
             .antMatchers("/api/**/non-member/**").permitAll()


### PR DESCRIPTION
## 구현내용

간단한 버그 수정입니다.

role 이 여러개인데 깜빡하고 USER, ADMIN 만 추가했네요